### PR TITLE
Add functionality for checkpoint & level reloads to reset grab counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+.vs/ObjectGrabber/FileContentIndex/read.lock
+.vs/ObjectGrabber/v17/.suo
+reloadPlugin.bat
+.vs/ObjectGrabber/FileContentIndex/8a161f93-2a8f-4e49-9a57-f527e26a6da7.vsidx


### PR DESCRIPTION
- Add variable to track grab counter at each level start, `grabsAtLevel`
- Add variable to track grab counter at each checkpoint reached, `grabsAtCP`
- Implement Harmony patching for reloading a level, to reset the grab counter to `grabsAtLevel`
- Implement Harmony patching for reloading a checkpoint, to reset the grab counter to `grabsAtCP`
- Add & implement method for refreshing grab text
- Add documentation